### PR TITLE
Добавлена навигация по изображениям в полноэкранном режиме

### DIFF
--- a/Dedupligator.App/MainWindow.axaml
+++ b/Dedupligator.App/MainWindow.axaml
@@ -44,6 +44,33 @@
       <Setter Property="Padding" Value="8"/>
       <Setter Property="Margin" Value="4"/>
     </Style>
+
+    <Style Selector="Button.nav-button">
+      <Setter Property="Background" Value="Transparent"/>
+      <Setter Property="Foreground" Value="Transparent"/>
+      <Setter Property="HorizontalAlignment" Value="Stretch"/>
+      <Setter Property="VerticalAlignment" Value="Stretch"/>
+      <Setter Property="BorderThickness" Value="0"/>
+      <Setter Property="CornerRadius" Value="0"/>
+      <Setter Property="FontSize" Value="32"/>
+      <Setter Property="FontWeight" Value="Bold"/>
+      <Setter Property="Template">
+        <ControlTemplate>
+          <Border Name="border"
+                  Background="{TemplateBinding Background}"
+                  BorderThickness="{TemplateBinding BorderThickness}">
+            <ContentPresenter Content="{TemplateBinding Content}"
+                              Foreground="{TemplateBinding Foreground}"
+                              HorizontalAlignment="Center"
+                              VerticalAlignment="Center"/>
+          </Border>
+        </ControlTemplate>
+      </Setter>
+    </Style>
+    <Style Selector="Button.nav-button:pointerover">
+      <Setter Property="Background" Value="{DynamicResource SemiColorText3}"/>
+      <Setter Property="Foreground" Value="{DynamicResource SemiColorNavBackground}"/>
+    </Style>
   </Window.Styles>
 
   <Grid RowDefinitions="*,Auto"
@@ -196,27 +223,48 @@
 
           <Grid Margin="0">
             <!-- Полноэкранное изображение -->
-            <Border Background="{DynamicResource SemiGrey1Color}"
-                    IsVisible="{Binding SelectedImage, Converter={x:Static ObjectConverters.IsNotNull}}"
-                    CornerRadius="6"
-                    ZIndex="100">
-              <Grid RowDefinitions="*,Auto" ColumnDefinitions="*,Auto">
-                <Image Grid.Row="0" Grid.Column="0" Grid.RowSpan="2" Grid.ColumnSpan="2"
-                       Source="{Binding SelectedImage}"
-                       Stretch="Uniform"
-                       Margin="0"/>
+            <Grid ColumnDefinitions="*, 30"
+                  IsVisible="{Binding SelectedImage, Converter={x:Static ObjectConverters.IsNotNull}}"
+                  ZIndex="100">
 
-                <Button Grid.Row="0" Grid.Column="1"
-                        HorizontalAlignment="Right" VerticalAlignment="Top"
-                        Margin="8" Width="32" Height="32" CornerRadius="16"
-                        Padding="0"
-                        HorizontalContentAlignment="Center"
-                        VerticalContentAlignment="Center"
-                        Background="{DynamicResource DangerColor}"
-                        Command="{Binding CloseFullScreenCommand}"
-                        Content="✕"/>
-              </Grid>
-            </Border>
+              <!-- Контейнер для центрирования -->
+              <Border Grid.Column="0"
+                      HorizontalAlignment="Center"
+                      VerticalAlignment="Center"
+                      Background="Transparent">
+
+                <Grid>
+                  <!-- Основное изображение -->
+                  <Image Source="{Binding SelectedImage}"
+                         Stretch="Uniform"
+                         x:Name="PreviewImage"/>
+
+                  <!-- Кнопки по бокам -->
+                  <Grid ColumnDefinitions="50, *, 50" Margin="0">
+
+                    <!-- Левая кнопка -->
+                    <Button Grid.Column="0"
+                            Content="‹"
+                            Classes="nav-button"
+                            Command="{Binding PreviousImageCommand}"/>
+
+                    <!-- Правая кнопка -->
+                    <Button Grid.Column="2"
+                            Content="›"
+                            Classes="nav-button"
+                            Command="{Binding NextImageCommand}"/>
+                  </Grid>
+                </Grid>
+              </Border>
+
+              <Button Grid.Column="1"
+                      HorizontalAlignment="Right" VerticalAlignment="Top"
+                      Margin="8" Width="32" Height="32" CornerRadius="16"
+                      Padding="0"
+                      Command="{Binding CloseFullScreenCommand}"
+                      Foreground="{DynamicResource SemiColorDanger}"
+                      Content="✕"/>
+            </Grid>
 
             <!-- Обычный режим с сеткой превью -->
             <Grid RowDefinitions="*,Auto"

--- a/Dedupligator.App/ViewModels/MainWindowViewModel.cs
+++ b/Dedupligator.App/ViewModels/MainWindowViewModel.cs
@@ -28,6 +28,7 @@ namespace Dedupligator.App.ViewModels
   {
     private const int PreviewImageMaxWidth = 250;
     private bool _disposed = false;
+    private string? _currentImagePath;
     private readonly AsyncDebouncer _debouncer = new(500);
     private readonly IDuplicateMatchStrategyFactory _strategyFactory;
     private readonly ILogger<MainWindowViewModel> _logger;
@@ -87,6 +88,18 @@ namespace Dedupligator.App.ViewModels
 
 
     private bool CanExecuteScanFolder => SelectedFolderPath is not null;
+
+    [RelayCommand]
+    private async Task PreviousImage()
+    {
+      await NavigateImageAsync(-1);
+    }
+
+    [RelayCommand]
+    private async Task NextImage()
+    {
+      await NavigateImageAsync(1);
+    }
 
     [RelayCommand(CanExecute = nameof(CanExecuteScanFolder))]
     private async Task ScanFolder()
@@ -162,6 +175,7 @@ namespace Dedupligator.App.ViewModels
     {
       if (imageVm != null)
       {
+        _currentImagePath = imageVm.FilePath;
         var (Width, _) = await ImageHelper.GetImageDimensionsAsync(imageVm.FilePath);
         var image = await ImageHelper.LoadImageAsync(imageVm.FilePath, (int)Width);
         SelectedImage = image.Bitmap;
@@ -172,6 +186,12 @@ namespace Dedupligator.App.ViewModels
     private void CloseFullScreen(ImagePreviewViewModel? imageVm)
     {
       CloseFullScreen();
+    }
+
+    private void CloseFullScreen()
+    {
+      _currentImagePath = null;
+      SelectedImage = null;
     }
 
     [RelayCommand]
@@ -187,9 +207,23 @@ namespace Dedupligator.App.ViewModels
       IsDarkTheme = theme == ThemeVariant.Dark;
     }
 
-    private void CloseFullScreen()
+    private async Task NavigateImageAsync(int direction)
     {
-      SelectedImage = null;
+      if (SelectedFileGroup == null || FilePreviews.Count == 0)
+        return;
+
+      var currentIndex = FilePreviews
+          .Select((preview, index) => new { preview, index })
+          .FirstOrDefault(x => x.preview.FilePath == _currentImagePath)?.index ?? -1;
+
+      if (currentIndex == -1)
+      {
+        await OpenFullScreen(FilePreviews[0]);
+        return;
+      }
+
+      var newIndex = (currentIndex + direction + FilePreviews.Count) % FilePreviews.Count;
+      await OpenFullScreen(FilePreviews[newIndex]);
     }
 
     private IDuplicateMatchStrategy CreateStrategy()


### PR DESCRIPTION
## feat: Добавлена навигация по изображениям в полноэкранном режиме

- Добавлены кнопки "Вперед"/"Назад" для перехода между изображениями
- Кнопки появляются при наведении курсора на изображение
- Реализована циклическая навигация по текущей группе дубликатов
- Удобные прямоугольные кнопки на всю высоту изображения

Теперь пользователи могут легко просматривать все изображения в группе без необходимости выхода из полноэкранного режима.