### PR TITLE
Architecture hardening for duplicate scan and resource lifecycle

### DIFF
--- a/Dedupligator.App/App.axaml.cs
+++ b/Dedupligator.App/App.axaml.cs
@@ -118,7 +118,8 @@ namespace Dedupligator.App
         builder.SetMinimumLevel(LogLevel.Debug);
       });
       services.AddTransient<DuplicateFinder>();
-      services.AddSingleton<IDuplicateMatchStrategyFactory, DuplicateMatchStrategyFactory>();
+      services.AddSingleton<DuplicateMatchStrategyFactory>();
+      services.AddSingleton<IDuplicateMatchStrategyFactory>(sp => sp.GetRequiredService<DuplicateMatchStrategyFactory>());
       services.AddScoped<MainWindowViewModel>();
     }
   }

--- a/Dedupligator.App/Collections/ObservableRangeCollection.cs
+++ b/Dedupligator.App/Collections/ObservableRangeCollection.cs
@@ -46,6 +46,14 @@ namespace Dedupligator.App.Collections
       if (Items.Count == 0 && list.Count == 0)
         return;
 
+      foreach (var p in Items)
+      {
+        if (p is IDisposable disposable)
+        {
+          disposable.Dispose();
+        }
+      }
+
       Items.Clear();
 
       if (list.Count == 0)

--- a/Dedupligator.App/ViewModels/ImagePreviewViewModel.cs
+++ b/Dedupligator.App/ViewModels/ImagePreviewViewModel.cs
@@ -8,12 +8,23 @@ using System.Threading.Tasks;
 
 namespace Dedupligator.App.ViewModels
 {
-  public partial class ImagePreviewViewModel : ViewModelBase
+  public sealed partial class ImagePreviewViewModel : ViewModelBase, IDisposable
   {
     private readonly ILogger<ImagePreviewViewModel> _logger;
-
-    [ObservableProperty]
     private Bitmap? _imagePreview;
+
+    public Bitmap? ImagePreview
+    {
+      get => _imagePreview;
+      set
+      {
+        if (ReferenceEquals(_imagePreview, value))
+          return;
+
+        _imagePreview?.Dispose();
+        SetProperty(ref _imagePreview, value);
+      }
+    }
 
     [ObservableProperty]
     private string? _resolution;
@@ -65,6 +76,11 @@ namespace Dedupligator.App.ViewModels
       FileSize = fileSize;
 
       _logger.LogDebug("Создан ImagePreviewViewModel для файла: {FileName}", fileName);
+    }
+
+    public void Dispose()
+    {
+      ImagePreview = null;
     }
   }
 }

--- a/Dedupligator.App/ViewModels/MainWindowViewModel.cs
+++ b/Dedupligator.App/ViewModels/MainWindowViewModel.cs
@@ -113,7 +113,6 @@ namespace Dedupligator.App.ViewModels
         return;
 
       var strategy = CreateStrategy();
-      _duplicateFinder.SetStrategy(strategy);
 
       IsProcess = true;
       DuplicateGroups.Clear();
@@ -130,6 +129,7 @@ namespace Dedupligator.App.ViewModels
         _findDuplicatesCancellationTokenSource = new CancellationTokenSource();
         var duplicateGroups = await Task.Run(() =>
           _duplicateFinder.FindDuplicates(
+            strategy,
             SelectedFolderPath, 
             progress, 
             _findDuplicatesCancellationTokenSource.Token));

--- a/Dedupligator.App/ViewModels/MainWindowViewModel.cs
+++ b/Dedupligator.App/ViewModels/MainWindowViewModel.cs
@@ -51,6 +51,8 @@ namespace Dedupligator.App.ViewModels
     private ObservableRangeCollection<ImagePreviewViewModel> _filePreviews = [];
 
     [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ScanFolderCommand))]
+    [NotifyCanExecuteChangedFor(nameof(StopScanFolderCommand))]
     private bool _isProcess;
 
     [ObservableProperty]
@@ -91,9 +93,6 @@ namespace Dedupligator.App.ViewModels
     public string? SelectedFolderPath => SelectedFolder?.GetSafeLocalPath(_logger);
     public static string AppVersion { get; } = $"v{GetAppVersion()}";
 
-
-    private bool CanExecuteScanFolder => SelectedFolderPath is not null;
-
     [RelayCommand]
     private async Task PreviousImage()
     {
@@ -105,6 +104,8 @@ namespace Dedupligator.App.ViewModels
     {
       await NavigateImageAsync(1);
     }
+
+    private bool CanExecuteScanFolder => SelectedFolderPath is not null && !IsProcess;
 
     [RelayCommand(CanExecute = nameof(CanExecuteScanFolder))]
     private async Task ScanFolder()
@@ -157,7 +158,9 @@ namespace Dedupligator.App.ViewModels
       }
     }
 
-    [RelayCommand]
+    private bool CanExecuteStopScanFolder => IsProcess;
+
+    [RelayCommand(CanExecute = nameof(CanExecuteStopScanFolder))]
     private void StopScanFolder()
     {
       _findDuplicatesCancellationTokenSource?.Cancel();

--- a/Dedupligator.App/ViewModels/MainWindowViewModel.cs
+++ b/Dedupligator.App/ViewModels/MainWindowViewModel.cs
@@ -1,459 +1,1 @@
-﻿using Avalonia;
-using Avalonia.Media.Imaging;
-using Avalonia.Platform.Storage;
-using Avalonia.Styling;
-using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
-using Dedupligator.App.Collections;
-using Dedupligator.App.Helpers;
-using Dedupligator.App.Models;
-using Dedupligator.Common.Helpers;
-using Dedupligator.Common.Models;
-using Dedupligator.Services;
-using Dedupligator.Services.Cache;
-using Dedupligator.Services.DuplicateFinders;
-using Dedupligator.Services.Factories;
-using Microsoft.Extensions.Logging;
-using Semi.Avalonia;
-using SixLabors.ImageSharp.Metadata.Profiles.Exif;
-using System;
-using System.Collections.Specialized;
-using System.ComponentModel;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Dedupligator.App.ViewModels
-{
-  public partial class MainWindowViewModel : ViewModelBase, IDisposable
-  {
-    private const int PreviewImageMaxWidth = 250;
-    private bool _disposed = false;
-    private readonly AsyncDebouncer _debouncer = new(500);
-    private readonly IDuplicateMatchStrategyFactory _strategyFactory;
-    private readonly ILogger<MainWindowViewModel> _logger;
-    private readonly ILoggerFactory _loggerFactory;
-    private readonly DuplicateFinder _duplicateFinder;
-
-    private CancellationTokenSource? _findDuplicatesCancellationTokenSource;
-
-    [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(ScanFolderCommand))]
-    [NotifyPropertyChangedFor(nameof(SelectedFolderPath))]
-    private IStorageFolder? _selectedFolder;
-
-    [ObservableProperty]
-    private ObservableRangeCollection<DuplicateGroup> _duplicateGroups = [];
-
-    [ObservableProperty]
-    private ObservableRangeCollection<ImagePreviewViewModel> _filePreviews = [];
-
-    [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(ScanFolderCommand))]
-    [NotifyCanExecuteChangedFor(nameof(StopScanFolderCommand))]
-    private bool _isProcess;
-
-    [ObservableProperty]
-    private bool _useNeuro;
-
-    [ObservableProperty]
-    private double _progress;
-
-    [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(RemoveFilesCommand))]
-    private DuplicateGroup? _selectedFileGroup;
-
-    [ObservableProperty]
-    private bool _useExactMatch = true;
-
-    private Bitmap? _selectedImage;
-    public Bitmap? SelectedImage
-    {
-      get => _selectedImage;
-      set
-      {
-        _selectedImage?.Dispose();
-        SetProperty(ref _selectedImage, value);
-      }
-    }
-
-    [ObservableProperty]
-    private float _similarityThreshold = 0.85f;
-
-    [ObservableProperty]
-    private bool _isDarkTheme;
-
-    [ObservableProperty]
-    private ImageInfo? _currentImageInfo;
-
-    public int TotalFiles => DuplicateGroups.Sum(x => x.FileCount);
-    public int TotalGroup => DuplicateGroups.Count;
-    public string? SelectedFolderPath => SelectedFolder?.GetSafeLocalPath(_logger);
-    public static string AppVersion { get; } = $"v{GetAppVersion()}";
-
-    [RelayCommand]
-    private async Task PreviousImage()
-    {
-      await NavigateImageAsync(-1);
-    }
-
-    [RelayCommand]
-    private async Task NextImage()
-    {
-      await NavigateImageAsync(1);
-    }
-
-    private bool CanExecuteScanFolder => SelectedFolderPath is not null && !IsProcess;
-
-    [RelayCommand(CanExecute = nameof(CanExecuteScanFolder))]
-    private async Task ScanFolder()
-    {
-      if (SelectedFolderPath is null || !Directory.Exists(SelectedFolderPath))
-        return;
-
-      var strategy = CreateStrategy();
-
-      IsProcess = true;
-      DuplicateGroups.Clear();
-      FilePreviews.Clear();
-      Progress = 0;
-
-      try
-      {
-        var progress = new Progress<double>(p =>
-        {
-          Progress = p;
-        });
-
-        _findDuplicatesCancellationTokenSource = new CancellationTokenSource();
-        var duplicateGroups = await Task.Run(() =>
-          _duplicateFinder.FindDuplicates(
-            strategy,
-            SelectedFolderPath, 
-            progress, 
-            _findDuplicatesCancellationTokenSource.Token));
-
-        var groupsForUi = duplicateGroups.Select(group => new DuplicateGroup(
-            GroupName: group[0].Name,
-            FileCount: group.Count,
-            TotalSize: group.Sum(x => x.Length).ToFileSizeString(),
-            Files: group
-        )).ToList();
-
-        DuplicateGroups.ReplaceWith(groupsForUi);
-
-        SelectedFileGroup = DuplicateGroups.Count > 0 ? DuplicateGroups[0] : null;
-      }
-      finally
-      {
-        IsProcess = false;
-        _findDuplicatesCancellationTokenSource?.Dispose();
-
-        if (strategy is ICachedDuplicateMatchStrategy cachedStrategy)
-        {
-          cachedStrategy.ClearCache();
-        }
-      }
-    }
-
-    private bool CanExecuteStopScanFolder => IsProcess;
-
-    [RelayCommand(CanExecute = nameof(CanExecuteStopScanFolder))]
-    private void StopScanFolder()
-    {
-      _findDuplicatesCancellationTokenSource?.Cancel();
-    }
-
-    private bool CanExecuteRemoveFiles => FilePreviews.Any(x => x.MarkedForDeletion);
-
-    [RelayCommand(CanExecute = nameof(CanExecuteRemoveFiles))]
-    private void RemoveFiles()
-    {
-      var itemsToRemove = FilePreviews.Where(x => x.MarkedForDeletion).ToList();
-      foreach (var item in itemsToRemove)
-      {
-        FilePreviews.Remove(item);
-      }
-    }
-
-    [RelayCommand]
-    private async Task OpenFullScreen(ImagePreviewViewModel? imageVm)
-    {
-      if (imageVm != null)
-      {
-        var (Width, Height) = await ImageHelper.GetImageDimensionsAsync(imageVm.FilePath);
-        var image = await ImageHelper.LoadImageAsync(imageVm.FilePath, (int)Width);
-        SelectedImage = image.Bitmap;
-
-        var baseInfo = ImageInfo.CreateBasic(
-            imageVm.FilePath,
-            new FileInfo(imageVm.FilePath).Length,
-            Width,
-            Height
-        );
-
-        CurrentImageInfo = await LoadExifDataAsync(baseInfo, imageVm.FilePath);
-      }
-    }
-
-    [RelayCommand]
-    private void CloseFullScreen(ImagePreviewViewModel? imageVm)
-    {
-      CloseFullScreen();
-    }
-
-    private void CloseFullScreen()
-    {
-      CurrentImageInfo = null;
-      SelectedImage = null;
-    }
-
-    [RelayCommand]
-    private void ToggleTheme()
-    {
-      var app = Application.Current;
-      if (app is null) return;
-      var theme = app.ActualThemeVariant;
-      app.RequestedThemeVariant = theme == ThemeVariant.Dark ? ThemeVariant.Light : ThemeVariant.Dark;
-      app.UnregisterFollowSystemTheme();
-
-      theme = app.ActualThemeVariant;
-      IsDarkTheme = theme == ThemeVariant.Dark;
-    }
-
-    [RelayCommand]
-    private async Task OpenContainingFolder(string filePath)
-    {
-      _logger.LogDebug("Открытие папки с файлом: {FilePath}", filePath);
-
-      await FileExplorerHelper.OpenFolderWithFileAsync(
-        filePath,
-        async error =>
-        {
-          _logger.LogWarning("Ошибка открытия папки: {ErrorMessage}", error);
-          await Task.CompletedTask;
-        });
-    }
-
-    private static async Task<ImageInfo> LoadExifDataAsync(ImageInfo baseInfo, string filePath)
-    {
-      try
-      {
-        using var image = await SixLabors.ImageSharp.Image.LoadAsync(filePath);
-        if (image.Metadata.ExifProfile == null)
-          return baseInfo;
-
-        var exif = image.Metadata.ExifProfile;
-
-        var make = exif.Values.FirstOrDefault(x => x.Tag == ExifTag.Make)?.GetValue()?.ToString();
-        var model = exif.Values.FirstOrDefault(x => x.Tag == ExifTag.Model)?.GetValue()?.ToString();
-        var dateTaken = exif.Values.FirstOrDefault(x => x.Tag == ExifTag.DateTime)?.GetValue()?.ToString();
-
-        return baseInfo with
-        {
-          CameraModel = $"{make} {model}".Trim(),
-          DateTaken = dateTaken ?? string.Empty,
-          Exposure = ImageInfo.GetExposureString(exif)
-        };
-      }
-      catch
-      {
-        return baseInfo;
-      }
-    }
-
-    private async Task NavigateImageAsync(int direction)
-    {
-      if (SelectedFileGroup == null || FilePreviews.Count == 0 || CurrentImageInfo == null)
-        return;
-
-      var currentIndex = FilePreviews
-          .Select((preview, index) => new { preview, index })
-          .FirstOrDefault(x => x.preview.FilePath == CurrentImageInfo.FilePath)?.index ?? -1;
-
-      if (currentIndex == -1)
-      {
-        await OpenFullScreen(FilePreviews[0]);
-        return;
-      }
-
-      var newIndex = (currentIndex + direction + FilePreviews.Count) % FilePreviews.Count;
-      await OpenFullScreen(FilePreviews[newIndex]);
-    }
-
-    private IDuplicateMatchStrategy CreateStrategy()
-    {
-      if (UseNeuro)
-        return _strategyFactory.CreateNeuralSimilarityStrategy(SimilarityThreshold);
-
-      if (UseExactMatch)
-        return _strategyFactory.CreateExactMatchStrategy();
-
-      return _strategyFactory.CreateSimilarImageStrategy();
-    }
-
-    async partial void OnSelectedFileGroupChanged(DuplicateGroup? oldValue, DuplicateGroup? newValue)
-    {
-      if (newValue == null)
-        return;
-
-      var previews = newValue.Files.Select(file => new ImagePreviewViewModel
-      (
-        file.Name,
-        file.FullName,
-        file.Length.ToFileSizeString(),
-        _loggerFactory.CreateLogger<ImagePreviewViewModel>()
-      )).ToList();
-
-      FilePreviews.ReplaceWith(previews);
-
-      await _debouncer.DebounceAsync(async () =>
-      {
-        var options = new ParallelOptions { MaxDegreeOfParallelism = 4 };
-        await Parallel.ForEachAsync(FilePreviews.ToList(), options, async (preview, ct) =>
-        {
-          await preview.LoadImageAsync(PreviewImageMaxWidth);
-        });
-      });
-    }
-
-    private void FilePreviews_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
-    {
-      switch (e.Action)
-      {
-        case NotifyCollectionChangedAction.Add:
-        case NotifyCollectionChangedAction.Replace:
-        case NotifyCollectionChangedAction.Move:
-          if (e.NewItems != null)
-          {
-            foreach (ImagePreviewViewModel item in e.NewItems)
-            {
-              item.PropertyChanged += ImagePreview_PropertyChanged;
-            }
-          }
-          break;
-
-        case NotifyCollectionChangedAction.Remove:
-          if (e.OldItems != null)
-          {
-            foreach (ImagePreviewViewModel item in e.OldItems)
-            {
-              item.PropertyChanged -= ImagePreview_PropertyChanged;
-            }
-          }
-          break;
-
-        case NotifyCollectionChangedAction.Reset:
-          // Коллекция полностью изменилась — нужно обработать ВСЕ элементы
-          if (FilePreviews.Count > 0)
-          {
-            // Отписываем старые (на всякий случай)
-            foreach (var item in FilePreviews)
-            {
-              item.PropertyChanged -= ImagePreview_PropertyChanged;
-            }
-            // Подписываем снова
-            foreach (var item in FilePreviews)
-            {
-              item.PropertyChanged += ImagePreview_PropertyChanged;
-            }
-          }
-
-          CloseFullScreen();
-          break;
-      }
-
-
-      RemoveFilesCommand.NotifyCanExecuteChanged();
-    }
-
-    private void ImagePreview_PropertyChanged(object? sender, PropertyChangedEventArgs e)
-    {
-      if (e.PropertyName == nameof(ImagePreviewViewModel.MarkedForDeletion))
-      {
-        RemoveFilesCommand.NotifyCanExecuteChanged();
-      }
-    }
-
-    private void DuplicateGroups_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
-    {
-      OnPropertyChanged(nameof(TotalFiles));
-      OnPropertyChanged(nameof(TotalGroup));
-    }
-
-    private static string GetAppVersion()
-    {
-      try
-      {
-        var assembly = Assembly.GetExecutingAssembly();
-        var version = assembly.GetName().Version;
-        return version != null ? $"{version.Major}.{version.Minor}.{version.Build}" : "0.1.0";
-      }
-      catch
-      {
-        return "0.1.0";
-      }
-    }
-
-    public void Dispose()
-    {
-      Dispose(true);
-      GC.SuppressFinalize(this);
-    }
-
-    protected virtual void Dispose(bool disposing)
-    {
-      if (!_disposed)
-      {
-        if (disposing)
-        {
-          // Освобождаем управляемые ресурсы
-          DuplicateGroups.CollectionChanged -= DuplicateGroups_CollectionChanged;
-          FilePreviews.CollectionChanged -= FilePreviews_CollectionChanged;
-
-          // Отписываемся от всех элементов
-          foreach (var preview in FilePreviews)
-          {
-            preview.PropertyChanged -= ImagePreview_PropertyChanged;
-          }
-
-          _findDuplicatesCancellationTokenSource?.Dispose();
-          SelectedImage?.Dispose();
-        }
-
-        _disposed = true;
-      }
-    }
-
-    ~MainWindowViewModel()
-    {
-      Dispose(false);
-    }
-
-    public MainWindowViewModel(
-      ILogger<MainWindowViewModel> logger,
-      IDuplicateMatchStrategyFactory strategyFactory,
-      DuplicateFinder duplicateFinder,
-      ILoggerFactory loggerFactory)
-    {
-      _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-      _strategyFactory = strategyFactory ?? throw new ArgumentNullException(nameof(strategyFactory));
-      _duplicateFinder = duplicateFinder ?? throw new ArgumentNullException(nameof(duplicateFinder));
-      _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
-
-      DuplicateGroups.CollectionChanged += DuplicateGroups_CollectionChanged;
-      FilePreviews.CollectionChanged+= FilePreviews_CollectionChanged;
-    }
-
-    /// <summary>
-    /// Конструктор для работы визуального редактора
-    /// </summary>
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
-    public MainWindowViewModel()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
-    {
-    }
-  }
-}
+﻿using Avalonia;using Avalonia.Media.Imaging;using Avalonia.Platform.Storage;using Avalonia.Styling;using CommunityToolkit.Mvvm.ComponentModel;using CommunityToolkit.Mvvm.Input;using Dedupligator.App.Collections;using Dedupligator.App.Helpers;using Dedupligator.App.Models;using Dedupligator.Common.Helpers;using Dedupligator.Common.Models;using Dedupligator.Services;using Dedupligator.Services.Cache;using Dedupligator.Services.DuplicateFinders;using Dedupligator.Services.Factories;using Microsoft.Extensions.Logging;using Semi.Avalonia;using SixLabors.ImageSharp.Metadata.Profiles.Exif;using System;using System.Collections.Specialized;using System.ComponentModel;using System.IO;using System.Linq;using System.Reflection;using System.Threading;using System.Threading.Tasks;namespace Dedupligator.App.ViewModels{  public partial class MainWindowViewModel : ViewModelBase, IDisposable  {    private const int PreviewImageMaxWidth = 250;    private bool _disposed = false;    private readonly AsyncDebouncer _debouncer = new(500);    private readonly IDuplicateMatchStrategyFactory _strategyFactory;    private readonly ILogger<MainWindowViewModel> _logger;    private readonly ILoggerFactory _loggerFactory;    private readonly DuplicateFinder _duplicateFinder;    private CancellationTokenSource? _findDuplicatesCancellationTokenSource;    [ObservableProperty]    [NotifyCanExecuteChangedFor(nameof(ScanFolderCommand))]    [NotifyPropertyChangedFor(nameof(SelectedFolderPath))]    private IStorageFolder? _selectedFolder;    [ObservableProperty]    private ObservableRangeCollection<DuplicateGroup> _duplicateGroups = [];    [ObservableProperty]    private ObservableRangeCollection<ImagePreviewViewModel> _filePreviews = [];    [ObservableProperty]    [NotifyCanExecuteChangedFor(nameof(ScanFolderCommand))]    [NotifyCanExecuteChangedFor(nameof(StopScanFolderCommand))]    private bool _isProcess;    [ObservableProperty]    private bool _useNeuro;    [ObservableProperty]    private double _progress;    [ObservableProperty]    [NotifyCanExecuteChangedFor(nameof(RemoveFilesCommand))]    private DuplicateGroup? _selectedFileGroup;    [ObservableProperty]    private bool _useExactMatch = true;    private Bitmap? _selectedImage;    public Bitmap? SelectedImage    {      get => _selectedImage;      set      {        _selectedImage?.Dispose();        SetProperty(ref _selectedImage, value);      }    }    [ObservableProperty]    private float _similarityThreshold = 0.85f;    [ObservableProperty]    private bool _isDarkTheme;    [ObservableProperty]    private ImageInfo? _currentImageInfo;    public int TotalFiles => DuplicateGroups.Sum(x => x.FileCount);    public int TotalGroup => DuplicateGroups.Count;    public string? SelectedFolderPath => SelectedFolder?.GetSafeLocalPath(_logger);    public static string AppVersion { get; } = $"v{GetAppVersion()}";    [RelayCommand]    private async Task PreviousImage()    {      await NavigateImageAsync(-1);    }    [RelayCommand]    private async Task NextImage()    {      await NavigateImageAsync(1);    }    private bool CanExecuteScanFolder => SelectedFolderPath is not null && !IsProcess;    [RelayCommand(CanExecute = nameof(CanExecuteScanFolder))]    private async Task ScanFolder()    {      if (SelectedFolderPath is null || !Directory.Exists(SelectedFolderPath))        return;      var strategy = CreateStrategy();      IsProcess = true;      DuplicateGroups.Clear();      FilePreviews.Clear();      Progress = 0;      try      {        var progress = new Progress<double>(p =>        {          Progress = p;        });        _findDuplicatesCancellationTokenSource = new CancellationTokenSource();        var duplicateGroups = await Task.Run(() =>          _duplicateFinder.FindDuplicates(            strategy,            SelectedFolderPath,             progress,             _findDuplicatesCancellationTokenSource.Token));        var groupsForUi = duplicateGroups.Select(group => new DuplicateGroup(            GroupName: group[0].Name,            FileCount: group.Count,            TotalSize: group.Sum(x => x.Length).ToFileSizeString(),            Files: group        )).ToList();        DuplicateGroups.ReplaceWith(groupsForUi);        SelectedFileGroup = DuplicateGroups.Count > 0 ? DuplicateGroups[0] : null;      }      finally      {        IsProcess = false;        _findDuplicatesCancellationTokenSource?.Dispose();        if (strategy is ICachedDuplicateMatchStrategy cachedStrategy)        {          cachedStrategy.ClearCache();        }      }    }    private bool CanExecuteStopScanFolder => IsProcess;    [RelayCommand(CanExecute = nameof(CanExecuteStopScanFolder))]    private void StopScanFolder()    {      _findDuplicatesCancellationTokenSource?.Cancel();    }    private bool CanExecuteRemoveFiles => FilePreviews.Any(x => x.MarkedForDeletion);    [RelayCommand(CanExecute = nameof(CanExecuteRemoveFiles))]    private void RemoveFiles()    {      var itemsToRemove = FilePreviews.Where(x => x.MarkedForDeletion).ToList();      foreach (var item in itemsToRemove)      {        item.Dispose();        FilePreviews.Remove(item);      }    }    [RelayCommand]    private async Task OpenFullScreen(ImagePreviewViewModel? imageVm)    {      if (imageVm != null)      {        var (Width, Height) = await ImageHelper.GetImageDimensionsAsync(imageVm.FilePath);        var image = await ImageHelper.LoadImageAsync(imageVm.FilePath, (int)Width);        SelectedImage = image.Bitmap;        var baseInfo = ImageInfo.CreateBasic(            imageVm.FilePath,            new FileInfo(imageVm.FilePath).Length,            Width,            Height        );        CurrentImageInfo = await LoadExifDataAsync(baseInfo, imageVm.FilePath);      }    }    [RelayCommand]    private void CloseFullScreen(ImagePreviewViewModel? imageVm)    {      CloseFullScreen();    }    private void CloseFullScreen()    {      CurrentImageInfo = null;      SelectedImage = null;    }    [RelayCommand]    private void ToggleTheme()    {      var app = Application.Current;      if (app is null) return;      var theme = app.ActualThemeVariant;      app.RequestedThemeVariant = theme == ThemeVariant.Dark ? ThemeVariant.Light : ThemeVariant.Dark;      app.UnregisterFollowSystemTheme();      theme = app.ActualThemeVariant;      IsDarkTheme = theme == ThemeVariant.Dark;    }    [RelayCommand]    private async Task OpenContainingFolder(string filePath)    {      _logger.LogDebug("Открытие папки с файлом: {FilePath}", filePath);      await FileExplorerHelper.OpenFolderWithFileAsync(        filePath,        async error =>        {          _logger.LogWarning("Ошибка открытия папки: {ErrorMessage}", error);          await Task.CompletedTask;        });    }    private static async Task<ImageInfo> LoadExifDataAsync(ImageInfo baseInfo, string filePath)    {      try      {        using var image = await SixLabors.ImageSharp.Image.LoadAsync(filePath);        if (image.Metadata.ExifProfile == null)          return baseInfo;        var exif = image.Metadata.ExifProfile;        var make = exif.Values.FirstOrDefault(x => x.Tag == ExifTag.Make)?.GetValue()?.ToString();        var model = exif.Values.FirstOrDefault(x => x.Tag == ExifTag.Model)?.GetValue()?.ToString();        var dateTaken = exif.Values.FirstOrDefault(x => x.Tag == ExifTag.DateTime)?.GetValue()?.ToString();        return baseInfo with        {          CameraModel = $"{make} {model}".Trim(),          DateTaken = dateTaken ?? string.Empty,          Exposure = ImageInfo.GetExposureString(exif)        };      }      catch      {        return baseInfo;      }    }    private async Task NavigateImageAsync(int direction)    {      if (SelectedFileGroup == null || FilePreviews.Count == 0 || CurrentImageInfo == null)        return;      var currentIndex = FilePreviews          .Select((preview, index) => new { preview, index })          .FirstOrDefault(x => x.preview.FilePath == CurrentImageInfo.FilePath)?.index ?? -1;      if (currentIndex == -1)      {        await OpenFullScreen(FilePreviews[0]);        return;      }      var newIndex = (currentIndex + direction + FilePreviews.Count) % FilePreviews.Count;      await OpenFullScreen(FilePreviews[newIndex]);    }    private IDuplicateMatchStrategy CreateStrategy()    {      if (UseNeuro)        return _strategyFactory.CreateNeuralSimilarityStrategy(SimilarityThreshold);      if (UseExactMatch)        return _strategyFactory.CreateExactMatchStrategy();      return _strategyFactory.CreateSimilarImageStrategy();    }    async partial void OnSelectedFileGroupChanged(DuplicateGroup? oldValue, DuplicateGroup? newValue)    {      if (newValue == null)        return;      var previews = newValue.Files.Select(file => new ImagePreviewViewModel      (        file.Name,        file.FullName,        file.Length.ToFileSizeString(),        _loggerFactory.CreateLogger<ImagePreviewViewModel>()      )).ToList();      FilePreviews.ReplaceWith(previews);      await _debouncer.DebounceAsync(async () =>      {        var options = new ParallelOptions { MaxDegreeOfParallelism = 4 };        await Parallel.ForEachAsync(FilePreviews.ToList(), options, async (preview, ct) =>        {          await preview.LoadImageAsync(PreviewImageMaxWidth);        });      });    }    private void FilePreviews_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)    {      switch (e.Action)      {        case NotifyCollectionChangedAction.Add:        case NotifyCollectionChangedAction.Replace:        case NotifyCollectionChangedAction.Move:          if (e.NewItems != null)          {            foreach (ImagePreviewViewModel item in e.NewItems)            {              item.PropertyChanged += ImagePreview_PropertyChanged;            }          }          break;        case NotifyCollectionChangedAction.Remove:          if (e.OldItems != null)          {            foreach (ImagePreviewViewModel item in e.OldItems)            {              item.PropertyChanged -= ImagePreview_PropertyChanged;            }          }          break;        case NotifyCollectionChangedAction.Reset:          // Коллекция полностью изменилась — нужно обработать ВСЕ элементы          if (FilePreviews.Count > 0)          {            // Отписываем старые (на всякий случай)            foreach (var item in FilePreviews)            {              item.PropertyChanged -= ImagePreview_PropertyChanged;            }            // Подписываем снова            foreach (var item in FilePreviews)            {              item.PropertyChanged += ImagePreview_PropertyChanged;            }          }          CloseFullScreen();          break;      }      RemoveFilesCommand.NotifyCanExecuteChanged();    }    private void ImagePreview_PropertyChanged(object? sender, PropertyChangedEventArgs e)    {      if (e.PropertyName == nameof(ImagePreviewViewModel.MarkedForDeletion))      {        RemoveFilesCommand.NotifyCanExecuteChanged();      }    }    private void DuplicateGroups_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)    {      OnPropertyChanged(nameof(TotalFiles));      OnPropertyChanged(nameof(TotalGroup));    }    private static string GetAppVersion()    {      try      {        var assembly = Assembly.GetExecutingAssembly();        var version = assembly.GetName().Version;        return version != null ? $"{version.Major}.{version.Minor}.{version.Build}" : "0.1.0";      }      catch      {        return "0.1.0";      }    }    public void Dispose()    {      Dispose(true);      GC.SuppressFinalize(this);    }    protected virtual void Dispose(bool disposing)    {      if (!_disposed)      {        if (disposing)        {          // Освобождаем управляемые ресурсы          DuplicateGroups.CollectionChanged -= DuplicateGroups_CollectionChanged;          FilePreviews.CollectionChanged -= FilePreviews_CollectionChanged;          // Отписываемся от всех элементов          foreach (var preview in FilePreviews)          {            preview.PropertyChanged -= ImagePreview_PropertyChanged;            preview.Dispose();          }          _findDuplicatesCancellationTokenSource?.Dispose();          SelectedImage?.Dispose();        }        _disposed = true;      }    }    ~MainWindowViewModel()    {      Dispose(false);    }    public MainWindowViewModel(      ILogger<MainWindowViewModel> logger,      IDuplicateMatchStrategyFactory strategyFactory,      DuplicateFinder duplicateFinder,      ILoggerFactory loggerFactory)    {      _logger = logger ?? throw new ArgumentNullException(nameof(logger));      _strategyFactory = strategyFactory ?? throw new ArgumentNullException(nameof(strategyFactory));      _duplicateFinder = duplicateFinder ?? throw new ArgumentNullException(nameof(duplicateFinder));      _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));      DuplicateGroups.CollectionChanged += DuplicateGroups_CollectionChanged;      FilePreviews.CollectionChanged+= FilePreviews_CollectionChanged;    }    /// <summary>    /// Конструктор для работы визуального редактора    /// </summary>#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.    public MainWindowViewModel()#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.    {    }  }}

--- a/Dedupligator.Services/DuplicateFinders/DuplicateFinder.cs
+++ b/Dedupligator.Services/DuplicateFinders/DuplicateFinder.cs
@@ -17,29 +17,18 @@ namespace Dedupligator.Services.DuplicateFinders
     private readonly ILogger<DuplicateFinder> _logger;
 
     /// <summary>
-    /// Стратегия поиска дубликатов файлов.
-    /// </summary>
-    private IDuplicateMatchStrategy? _strategy;
-
-    public void SetStrategy(IDuplicateMatchStrategy strategy)
-    {
-      _strategy = strategy ?? throw new ArgumentNullException(nameof(strategy));
-      _logger.LogDebug("Strategy set to: {StrategyType}", strategy.GetType().Name);
-    }
-
-    /// <summary>
     /// Находит дубликаты файлов в указанной директории и её поддиректориях.
     /// </summary>
     /// <param name="directoryPath">Путь к директории для поиска.</param>
     /// <param name="progressCallback">Колбэк для прогресса.</param>
     /// <returns>Список групп дубликатов.</returns>
-    public List<List<FileInfo>> FindDuplicates(string directoryPath, IProgress<double>? progress = null, CancellationToken cancellationToken = default)
+    public List<List<FileInfo>> FindDuplicates(
+      IDuplicateMatchStrategy strategy,
+      string directoryPath,
+      IProgress<double>? progress = null,
+      CancellationToken cancellationToken = default)
     {
-      if (_strategy == null)
-      {
-        throw new InvalidOperationException("Strategy not set. Call SetStrategy first.");
-      }
-
+      ArgumentNullException.ThrowIfNull(strategy);
       _logger.LogInformation("Начало поиска дубликатов в директории: {DirectoryPath}", directoryPath);
 
       const double SCAN_PHASE_WEIGHT = 0.01;    // 0% → 1%
@@ -77,6 +66,7 @@ namespace Dedupligator.Services.DuplicateFinders
       // 2. Группировка (с вычислением ключей)
       _logger.LogDebug("Фаза 2: Группировка файлов");
       var groupedFiles = GetGroupedFiles(
+          strategy,
           allFiles,
           progress,
           SCAN_PHASE_WEIGHT,
@@ -97,12 +87,13 @@ namespace Dedupligator.Services.DuplicateFinders
       // 3. Поиск дубликатов в группах
       _logger.LogDebug("Фаза 3: Поиск дубликатов в группах");
       var duplicateGroups = FindDuplicatesInGroupsWithThrottling(
-          groupedFiles,
-          progress,
-          SCAN_PHASE_WEIGHT + GROUP_PHASE_WEIGHT, // начало фазы
-          COMPARE_PHASE_WEIGHT,
-          _maxParallelism,
-          cancellationToken);
+        strategy,
+        groupedFiles,
+        progress,
+        SCAN_PHASE_WEIGHT + GROUP_PHASE_WEIGHT, // начало фазы
+        COMPARE_PHASE_WEIGHT,
+        _maxParallelism,
+        cancellationToken);
 
       _logger.LogInformation("Найдено групп дубликатов: {DuplicateGroupCount}", duplicateGroups.Count);
       _logger.LogInformation("Общее количество дубликатов: {TotalDuplicates}",
@@ -112,12 +103,13 @@ namespace Dedupligator.Services.DuplicateFinders
     }
 
     private List<List<FileInfo>> FindDuplicatesInGroupsWithThrottling(
-        IEnumerable<IGrouping<object, FileInfo>> groupedFiles,
-        IProgress<double>? progress,
-        double startPhase,
-        double phaseWeight,
-        int maxParallelism = 4,
-        CancellationToken cancellationToken = default)
+      IDuplicateMatchStrategy strategy,
+      IEnumerable<IGrouping<object, FileInfo>> groupedFiles,
+      IProgress<double>? progress,
+      double startPhase,
+      double phaseWeight,
+      int maxParallelism = 4,
+      CancellationToken cancellationToken = default)
     {
       var duplicateGroups = new ConcurrentBag<List<FileInfo>>();
       var totalFiles = groupedFiles.Sum(x => x.Count());
@@ -148,6 +140,7 @@ namespace Dedupligator.Services.DuplicateFinders
             _logger.LogTrace("Обработка группы из {GroupSize} файлов", groupFiles.Count);
 
             var groupDuplicates = FindDuplicateGroupsInFileGroup(
+              strategy,
               groupFiles,
               cancellationToken,
               () =>
@@ -182,7 +175,11 @@ namespace Dedupligator.Services.DuplicateFinders
       return [.. duplicateGroups];
     }
 
-    private List<List<FileInfo>> FindDuplicateGroupsInFileGroup(List<FileInfo> files, CancellationToken cancellationToken, Action? progressCallback = null)
+    private List<List<FileInfo>> FindDuplicateGroupsInFileGroup(
+      IDuplicateMatchStrategy strategy,
+      List<FileInfo> files,
+      CancellationToken cancellationToken,
+      Action? progressCallback = null)
     {
       var duplicateGroups = new List<List<FileInfo>>();
       var processedFiles = new HashSet<string>();
@@ -207,7 +204,7 @@ namespace Dedupligator.Services.DuplicateFinders
           if (processedFiles.Contains(otherFile.FullName))
             continue;
 
-          if (FilesAreDuplicates(currentFile, otherFile))
+          if (FilesAreDuplicates(strategy, currentFile, otherFile))
           {
             currentGroup.Add(otherFile);
             processedFiles.Add(otherFile.FullName);
@@ -232,11 +229,11 @@ namespace Dedupligator.Services.DuplicateFinders
     /// <param name="file1">Первый файл.</param>
     /// <param name="file2">Второй файл.</param>
     /// <returns>True если файлы дубликаты.</returns>
-    private bool FilesAreDuplicates(FileInfo file1, FileInfo file2)
+    private bool FilesAreDuplicates(IDuplicateMatchStrategy strategy, FileInfo file1, FileInfo file2)
     {
       try
       {
-        var areDuplicates = _strategy!.AreDuplicates(file1, file2);
+        var areDuplicates = strategy.AreDuplicates(file1, file2);
         if (areDuplicates)
         {
           _logger.LogTrace("Файлы являются дубликатами: {File1} == {File2}", file1.Name, file2.Name);
@@ -255,7 +252,9 @@ namespace Dedupligator.Services.DuplicateFinders
     /// </summary>
     /// <param name="allFiles">Все файлы для обработки.</param>
     /// <returns>Сгруппированные файлы.</returns>
-    private List<IGrouping<object, FileInfo>> GetGroupedFiles(List<FileInfo> allFiles,
+    private List<IGrouping<object, FileInfo>> GetGroupedFiles(
+      IDuplicateMatchStrategy strategy,
+      List<FileInfo> allFiles,
       IProgress<double>? progress,
       double startProgress,
       double phaseWeight,
@@ -267,7 +266,7 @@ namespace Dedupligator.Services.DuplicateFinders
 
       _logger.LogDebug("Группировка {FileCount} файлов", allFiles.Count);
 
-      if (!_strategy!.RequiresPreGrouping)
+      if (!strategy.RequiresPreGrouping)
       {
         progress?.Report((startProgress + phaseWeight) * 100);
         _logger.LogDebug("Стратегия не требует предварительной группировки");
@@ -290,7 +289,7 @@ namespace Dedupligator.Services.DuplicateFinders
           {
             try
             {
-              var key = _strategy.GroupingKeySelector(file);
+              var key = strategy.GroupingKeySelector(file);
               fileKeys[file] = key;
               _logger.LogTrace("Вычислен ключ для файла {FileName}: {Key}", file.Name, key);
             }

--- a/Dedupligator.Services/DuplicateFinders/NeuralSimilarityStrategy.cs
+++ b/Dedupligator.Services/DuplicateFinders/NeuralSimilarityStrategy.cs
@@ -134,6 +134,7 @@ namespace Dedupligator.Services.DuplicateFinders
         if (disposing)
         {
           _session?.Dispose();
+          _embeddingCache.Clear();
         }
       }
     }

--- a/Dedupligator.Services/DuplicateFinders/NeuralSimilarityStrategy.cs
+++ b/Dedupligator.Services/DuplicateFinders/NeuralSimilarityStrategy.cs
@@ -141,7 +141,7 @@ namespace Dedupligator.Services.DuplicateFinders
 
     public NeuralSimilarityStrategy(float Threshold)
     {
-      var modelPath = Path.Combine(Directory.GetCurrentDirectory(), "Assets", "mobilenetv2-7.onnx");
+      var modelPath = Path.Combine(AppContext.BaseDirectory, "Assets", "mobilenetv2-7.onnx");
       if (!File.Exists(modelPath))
         throw new FileNotFoundException($"Model file not found: {modelPath}");
 

--- a/Dedupligator.Services/Factories/DuplicateMatchStrategyFactory.cs
+++ b/Dedupligator.Services/Factories/DuplicateMatchStrategyFactory.cs
@@ -3,11 +3,12 @@ using System.Collections.Concurrent;
 
 namespace Dedupligator.Services.Factories
 {
-  public class DuplicateMatchStrategyFactory : IDuplicateMatchStrategyFactory
+  public sealed class DuplicateMatchStrategyFactory : IDuplicateMatchStrategyFactory, IDisposable
   {
     private readonly ConcurrentDictionary<float, NeuralSimilarityStrategy> _neuralCache = new();
     private readonly Lazy<ExactMatchStrategy> _exactMatchStrategy = new(() => new ExactMatchStrategy());
     private readonly Lazy<SimilarImageStrategy> _similarImageStrategy = new(() => new SimilarImageStrategy());
+    private bool _disposed;
 
     public IDuplicateMatchStrategy CreateExactMatchStrategy() => _exactMatchStrategy.Value;
 
@@ -15,7 +16,22 @@ namespace Dedupligator.Services.Factories
 
     public IDuplicateMatchStrategy CreateNeuralSimilarityStrategy(float threshold)
     {
+      ObjectDisposedException.ThrowIf(_disposed, this);
       return _neuralCache.GetOrAdd(threshold, t => new NeuralSimilarityStrategy(t));
+    }
+
+    public void Dispose()
+    {
+      if (_disposed)
+        return;
+
+      foreach (var strategy in _neuralCache.Values)
+      {
+        strategy.Dispose();
+      }
+
+      _neuralCache.Clear();
+      _disposed = true;
     }
   }
 }


### PR DESCRIPTION
## Summary

This PR improves stability around duplicate scanning and heavy resource lifecycle management.

### Included changes

- make `DuplicateFinder` stateless by passing strategy explicitly
- prevent concurrent scans from the UI
- dispose preview bitmaps when previews are replaced, removed, or cleaned up
- dispose cached neural strategies and ONNX sessions on shutdown
- resolve ONNX model path from `AppContext.BaseDirectory` instead of current working directory

## Why

These changes address several architectural and runtime risks:

- duplicate scan strategy could be mutated during concurrent runs
- repeated scans could be started from UI while one was already active
- preview `Bitmap` instances could accumulate and leak memory
- `InferenceSession` instances cached by the strategy factory were never explicitly disposed
- model loading depended on `Directory.GetCurrentDirectory()`, which is fragile for installed app launches
